### PR TITLE
Exclude empty credential values from masking

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
@@ -97,9 +97,17 @@ public class SecretBuildWrapper extends BuildWrapper {
     	Map<String,String> overrides = new HashMap<String,String>();
         for (MultiBinding<?> binding : bindings) {
             MultiBinding.MultiEnvironment environment = binding.bind(build, null, null, null);
-            overrides.putAll(environment.getValues());
+            for (String envKey : environment.getValues().keySet()) {
+                if (!environment.getValues().get(envKey).isEmpty()) {
+                    overrides.put(envKey, environment.getValues().get(envKey));
+                }
+            }
         }
-        return new BindingStep.Filter(overrides.values()).decorateLogger(build, logger);
+        if (!overrides.isEmpty()) {
+            return new BindingStep.Filter(overrides.values()).decorateLogger(build, logger);
+        } else {
+            return logger;
+        }
     }
 
     @Override public void makeSensitiveBuildVariables(AbstractBuild build, Set<String> sensitiveVariables) {


### PR DESCRIPTION
String conversion of secret file is empty, which causes the masking to happen to all empty characters, which causes the whole log to be masked if a secret file is being used. The secret file is not printed by default, and needs to masking. So, if a credentials string value is empty, then don't mask it.
